### PR TITLE
Dev/rfx product photo entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,24 @@ It is recommended that you generate your keys/password via https://passwordsgene
 
 Once you've setup your heroku app, you can just repeat steps 6 & 7 for continuous deployment, unless you need to add further environment variables.
 
+**heroku is fucking slow since the only hosting options are in US/Europe, i need a better free alternative that supports node.js / dotnet.
+it also fucking shuts down when it hasn't been accessed in a while, and boots up only when someone visits the site, which takes forever too.**
+
 ---
 ##### Features to be implemented / Bugs to be fixed, in no particular order:
+
+TODO: 
+products - need a 'variations' property save as jsonb or as a table? probably table (ProductVariations).
+might also need SKU for stock, see this design: https://stackoverflow.com/questions/45627859/entity-framework-core-challenge-modeling-product-variants-database-design-with
+[
+  {
+    id: int,
+    productId: int (not nullable)
+    size: string,
+    color: string,
+    stock: int
+  }
+]
 
 #### API
 
@@ -105,6 +121,7 @@ Once you've setup your heroku app, you can just repeat steps 6 & 7 for continuou
 - users management
   - change pw, confirm email, disable acct, lockout, reset password, forget username etc.
 - email functionality
+- site-wide search
 
 #### Sys
 - homepage banner module

--- a/client/projects/data/src/lib/models/product-photo.ts
+++ b/client/projects/data/src/lib/models/product-photo.ts
@@ -1,7 +1,6 @@
 export interface ProductPhoto {
   id: number;
   url: string;
-  publicId: string;
   createdAt: Date;
   isMain: boolean;
   productId: number;

--- a/client/projects/sys/src/app/feature-modules/products/products-list/products-list.component.ts
+++ b/client/projects/sys/src/app/feature-modules/products/products-list/products-list.component.ts
@@ -168,7 +168,6 @@ export class ProductsListComponent implements OnInit, OnDestroy {
             switchMap((productParams: ProductParams) => {
               return this.route.queryParamMap.pipe(
                 switchMap((params: ParamMap) => {
-                  console.log(productParams);
                   if (
                     params.has('productCategoryId') &&
                     params.get('productCategoryId') !== null
@@ -264,8 +263,6 @@ export class ProductsListComponent implements OnInit, OnDestroy {
         }
       }
     }
-
-    console.log(this.productParams);
 
     this.refresher$.next(this.productParams);
   }

--- a/server/Audi/DTOs/ProductDto.cs
+++ b/server/Audi/DTOs/ProductDto.cs
@@ -19,6 +19,6 @@ namespace Audi.DTOs
         public DateTime? DiscountDeadline { get; set; }
         public decimal Price { get; set; }
         public int Stock { get; set; }
-        public ICollection<ProductPhotoDto> Photos { get; set; }
+        public ICollection<ProductPhotoDto> Photos { get; set; } = new List<ProductPhotoDto>();
     }
 }

--- a/server/Audi/DTOs/ProductPhotoDto.cs
+++ b/server/Audi/DTOs/ProductPhotoDto.cs
@@ -6,7 +6,6 @@ namespace Audi.DTOs
     {
         public int Id { get; set; }
         public string Url { get; set; }
-        public string PublicId { get; set; }
         public DateTime CreatedAt { get; set; }
         public bool IsMain { get; set; }
         public int ProductId { get; set; }

--- a/server/Audi/Data/DataContext.cs
+++ b/server/Audi/Data/DataContext.cs
@@ -22,6 +22,7 @@ namespace Audi.Data
 
         public DbSet<ProductCategory> ProductCategories { get; set; }
         public DbSet<Product> Products { get; set; }
+        public DbSet<Photo> Photos { get; set; }
         public DbSet<ProductPhoto> ProductPhotos { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
@@ -55,7 +56,7 @@ namespace Audi.Data
                 .OnDelete(DeleteBehavior.Cascade);
 
             builder.Entity<Product>()
-                .HasMany(e => e.Photos)
+                .HasMany(e => e.ProductPhotos)
                 .WithOne(e => e.Product)
                 .HasForeignKey(e => e.ProductId)
                 .IsRequired()
@@ -68,6 +69,27 @@ namespace Audi.Data
                     v => JsonConvert.SerializeObject(v),
                     v => JsonConvert.DeserializeObject<WysiwygGrid>(v))
                 .HasDefaultValueSql("'{}'");
+
+            // relationship for: Product <-> ProductPhoto <-> Photo
+            builder.Entity<ProductPhoto>()
+                .HasKey(e => new { e.ProductId, e.PhotoId });
+
+            builder
+                .Entity<ProductPhoto>()
+                .HasOne(e => e.Product)
+                .WithMany(e => e.ProductPhotos)
+                .HasForeignKey(e => e.ProductId)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder
+                .Entity<ProductPhoto>()
+                .HasOne(e => e.Photo)
+                .WithMany(e => e.ProductPhotos)
+                .HasForeignKey(e => e.PhotoId)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+            // relationship end
 
             builder.ApplyUtcDateTimeConverter();
 

--- a/server/Audi/Data/Migrations/20210704144932_RfxProductPhotosEntity.Designer.cs
+++ b/server/Audi/Data/Migrations/20210704144932_RfxProductPhotosEntity.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Audi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace server.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210704144932_RfxProductPhotosEntity")]
+    partial class RfxProductPhotosEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/Audi/Data/Migrations/20210704144932_RfxProductPhotosEntity.cs
+++ b/server/Audi/Data/Migrations/20210704144932_RfxProductPhotosEntity.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace server.Data.Migrations
+{
+    public partial class RfxProductPhotosEntity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_product_photos",
+                table: "product_photos");
+
+            migrationBuilder.DropIndex(
+                name: "ix_product_photos_product_id",
+                table: "product_photos");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "product_photos");
+
+            migrationBuilder.DropColumn(
+                name: "public_id",
+                table: "product_photos");
+
+            migrationBuilder.DropColumn(
+                name: "url",
+                table: "product_photos");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "product_photos",
+                newName: "photo_id");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "photo_id",
+                table: "product_photos",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_product_photos",
+                table: "product_photos",
+                columns: new[] { "product_id", "photo_id" });
+
+            migrationBuilder.CreateTable(
+                name: "photos",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    url = table.Column<string>(type: "text", nullable: true),
+                    public_id = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_photos", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_product_photos_photo_id",
+                table: "product_photos",
+                column: "photo_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_product_photos_photos_photo_id",
+                table: "product_photos",
+                column: "photo_id",
+                principalTable: "photos",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_product_photos_photos_photo_id",
+                table: "product_photos");
+
+            migrationBuilder.DropTable(
+                name: "photos");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_product_photos",
+                table: "product_photos");
+
+            migrationBuilder.DropIndex(
+                name: "ix_product_photos_photo_id",
+                table: "product_photos");
+
+            migrationBuilder.RenameColumn(
+                name: "photo_id",
+                table: "product_photos",
+                newName: "id");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "product_photos",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "product_photos",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "public_id",
+                table: "product_photos",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "url",
+                table: "product_photos",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_product_photos",
+                table: "product_photos",
+                column: "id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_product_photos_product_id",
+                table: "product_photos",
+                column: "product_id");
+        }
+    }
+}

--- a/server/Audi/Data/PhotoRepository.cs
+++ b/server/Audi/Data/PhotoRepository.cs
@@ -20,21 +20,31 @@ namespace Audi.Data
             _context = context;
         }
 
-        public void AddProductPhoto(ProductPhoto photo)
+        public void AddPhoto(Photo photo)
         {
-            _context.ProductPhotos.Add(photo);
+            _context.Photos.Add(photo);
         }
 
-        public void DeleteProductPhoto(ProductPhoto photo)
+        public void AddProductPhoto(ProductPhoto productPhoto)
         {
-            _context.ProductPhotos.Remove(photo);
+            _context.ProductPhotos.Add(productPhoto);
         }
 
-        public async Task<ProductPhotoDto> GetProductPhotoByIdAsync(int photoId)
+        public void DeletePhoto(Photo photo)
+        {
+            _context.Photos.Remove(photo);
+        }
+
+        public void DeleteProductPhoto(ProductPhoto productPhoto)
+        {
+            _context.ProductPhotos.Remove(productPhoto);
+        }
+
+        public async Task<ProductPhotoDto> GetProductPhotoByIdAsync(int productPhotoId)
         {
             var photo = await _context.ProductPhotos
                 .ProjectTo<ProductPhotoDto>(_mapper.ConfigurationProvider)
-                .SingleOrDefaultAsync(p => p.Id == photoId);
+                .SingleOrDefaultAsync(p => p.Id == productPhotoId);
 
             return photo;
         }
@@ -43,27 +53,27 @@ namespace Audi.Data
         {
             var photos = await _context.Products
                 .Where(p => p.Id == productId)
-                .Select(p => p.Photos)
+                .Select(p => p.ProductPhotos)
                 .ProjectTo<ProductPhotoDto>(_mapper.ConfigurationProvider)
                 .ToListAsync();
 
             return photos;
         }
 
-        public async Task SetMainProductPhoto(ProductPhoto photo)
+        public async Task SetMainProductPhoto(ProductPhoto productPhoto)
         {
-            var productId = photo.ProductId;
+            var productId = productPhoto.ProductId;
 
             var product = await _context.Products
-                .Include(p => p.Photos)
+                .Include(p => p.ProductPhotos)
                 .FirstOrDefaultAsync(p => p.Id == productId);
 
-            foreach (var p in product.Photos)
+            foreach (var p in product.ProductPhotos)
             {
-                p.IsMain = p.Id == photo.Id;
+                p.IsMain = p.PhotoId == productPhoto.PhotoId;
             }
-            
-            _context.ProductPhotos.UpdateRange(product.Photos);
+
+            _context.ProductPhotos.UpdateRange(product.ProductPhotos);
         }
     }
 }

--- a/server/Audi/Data/ProductRepository.cs
+++ b/server/Audi/Data/ProductRepository.cs
@@ -98,7 +98,8 @@ namespace Audi.Data
         {
             var product = await _context.Products
                 .Include(p => p.ProductCategory)
-                .Include(p => p.Photos)
+                .Include(p => p.ProductPhotos)
+                    .ThenInclude(p => p.Photo)
                 .Where(p => p.Id == productId)
                 .FirstOrDefaultAsync();
 
@@ -121,7 +122,8 @@ namespace Audi.Data
         {
             var query = _context.Products
                 .Include(p => p.ProductCategory)
-                .Include(p => p.Photos)
+                .Include(p => p.ProductPhotos)
+                    .ThenInclude(p => p.Photo)
                 .Where(p =>
                     p.Language.ToLower().Trim() == productParams.Language.ToLower().Trim()
                 )
@@ -184,13 +186,14 @@ namespace Audi.Data
             _context.ProductCategories.Update(productCategory);
         }
 
-        public Task<Product> GetProductByProductPhotoIdAsync(int productPhotoId)
+        public Task<Product> GetProductByPhotoIdAsync(int photoId)
         {
             var product = _context.ProductPhotos
-                .Include(photo => photo.Product)
-                    .ThenInclude(product => product.Photos)
-                .Where(photo => photo.Id == productPhotoId)
-                .Select(photo => photo.Product)
+                .Include(productPhoto => productPhoto.Product)
+                    .ThenInclude(product => product.ProductPhotos)
+                        .ThenInclude(productPhoto => productPhoto.Photo)
+                .Where(productPhoto => productPhoto.PhotoId == photoId)
+                .Select(productPhoto => productPhoto.Product)
                 .SingleOrDefaultAsync();
 
             return product;

--- a/server/Audi/Entities/Photo.cs
+++ b/server/Audi/Entities/Photo.cs
@@ -1,6 +1,7 @@
 using System;
+using System.Collections.Generic;
 
-namespace Audi.Models
+namespace Audi.Entities
 {
     public class Photo
     {
@@ -8,5 +9,6 @@ namespace Audi.Models
         public string Url { get; set; }
         public string PublicId { get; set; }
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public ICollection<ProductPhoto> ProductPhotos { get; set; }
     }
 }

--- a/server/Audi/Entities/Product.cs
+++ b/server/Audi/Entities/Product.cs
@@ -20,6 +20,6 @@ namespace Audi.Entities
         public DateTime? DiscountDeadline { get; set; }
         public decimal Price { get; set; }
         public int Stock { get; set; }
-        public ICollection<ProductPhoto> Photos { get; set; }
+        public ICollection<ProductPhoto> ProductPhotos { get; set; }
     }
 }

--- a/server/Audi/Entities/ProductPhoto.cs
+++ b/server/Audi/Entities/ProductPhoto.cs
@@ -2,10 +2,12 @@ using Audi.Models;
 
 namespace Audi.Entities
 {
-    public class ProductPhoto : Photo
-    {
-        public bool IsMain { get; set; }
+    public class ProductPhoto
+{
+        public bool IsMain { get; set; } = false;
         public int ProductId { get; set; }
         public Product Product { get; set; }
+        public int PhotoId { get; set; }
+        public Photo Photo { get; set; }
     }
 }

--- a/server/Audi/Helpers/AutoMapperProfiles.cs
+++ b/server/Audi/Helpers/AutoMapperProfiles.cs
@@ -18,9 +18,28 @@ namespace Audi.Helpers
                     opt => opt.MapFrom(src => src.GetFullName())
                 );
 
-            CreateMap<Product, ProductDto>();
             CreateMap<ProductCategory, ProductCategoryDto>();
-            CreateMap<ProductPhoto, ProductPhotoDto>();
+            
+            CreateMap<ProductPhoto, ProductPhotoDto>()
+                .ForMember(
+                    dest => dest.Url,
+                    opt => opt.MapFrom(src => src.Photo.Url)
+                )
+                .ForMember(
+                    dest => dest.Id,
+                    opt => opt.MapFrom(src => src.PhotoId)
+                )
+                .ForMember(
+                    dest => dest.CreatedAt,
+                    opt => opt.MapFrom(src => src.Photo.CreatedAt)
+                );
+
+            CreateMap<Product, ProductDto>()
+                .ForMember(
+                    dest => dest.Photos,
+                    opt => opt.MapFrom(src => src.ProductPhotos)
+                );
+
 
             // reverse map from dto to entity model:
             CreateMap<RegisterDto, AppUser>();

--- a/server/Audi/Interfaces/IPhotoRepository.cs
+++ b/server/Audi/Interfaces/IPhotoRepository.cs
@@ -9,8 +9,10 @@ namespace Audi.Interfaces
     {
         Task<ProductPhotoDto> GetProductPhotoByIdAsync(int photoId);
         Task<IEnumerable<ProductPhotoDto>> GetProductPhotosByProductIdAsync(int productId);
-        void AddProductPhoto(ProductPhoto photo);
-        void DeleteProductPhoto(ProductPhoto photo);
-        Task SetMainProductPhoto(ProductPhoto photo);
+        void AddPhoto(Photo photo);
+        void DeletePhoto(Photo photo);
+        void AddProductPhoto(ProductPhoto productPhoto);
+        void DeleteProductPhoto(ProductPhoto productPhoto);
+        Task SetMainProductPhoto(ProductPhoto productPhoto);
     }
 }

--- a/server/Audi/Interfaces/IProductRepository.cs
+++ b/server/Audi/Interfaces/IProductRepository.cs
@@ -9,7 +9,7 @@ namespace Audi.Interfaces
     {
         void UpdateProduct(Product product);
         Task<Product> GetProductByIdAsync(int productId);
-        Task<Product> GetProductByProductPhotoIdAsync(int productPhotoId);
+        Task<Product> GetProductByPhotoIdAsync(int photoId);
         Task<PagedList<ProductDto>> GetProductsAsync(ProductParams productParams);
         void AddProduct(Product product);
         void DeleteProduct(Product product);

--- a/server/Audi/Properties/launchSettings.json
+++ b/server/Audi/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     "server": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {


### PR DESCRIPTION
Refactored ProductPhoto table into a relational table, and set Photos as its own entity instead of using it as an extendable model. 

new relationship: Product <-> ProductPhoto <-> Photo

this is a lot more scaleable and easier to extend when i want to add photo tables for other entities. I will only need to add another Entity and another EntityPhoto table.